### PR TITLE
Update provisioners_controller.rb

### DIFF
--- a/app/controllers/foreman_setup/provisioners_controller.rb
+++ b/app/controllers/foreman_setup/provisioners_controller.rb
@@ -41,7 +41,7 @@ module ForemanSetup
       network = @provisioner.provision_interface_data
       @provisioner.subnet ||= Subnet.find_by_network(network[:network])
       @provisioner.subnet ||= Subnet.new(network.slice(:network, :mask).merge(
-        :dns_primary => @provisioner.provision_interface_data[:ip],
+        :dns_primary => @provisioner.provision_interface_data[:ip]
       ))
 
       @provisioner.domain ||= @provisioner.host.domain


### PR DESCRIPTION
Got this error after installing and restarting Foreman:

Error message:
    /usr/share/foreman/vendor/ruby/1.8/gems/foreman_setup-1.0.1/app/controllers/foreman_setup/provisioners_controller.rb:45: syntax error, unexpected ')' )) ^
