### PR TITLE
Remove param due to installer changes

### DIFF
--- a/app/views/foreman_setup/provisioners/_step3.html.erb
+++ b/app/views/foreman_setup/provisioners/_step3.html.erb
@@ -26,7 +26,6 @@ foreman-installer \
   --foreman-proxy-dns-reverse=<%= provisioner.rdns_zone %> \
 <%= provisioner.dns_forwarders.map { |f| "  --foreman-proxy-dns-forwarders=#{f} \\" }.join("\n") %>
 <% if defined? Katello %>
-  --foreman-proxy-content-parent-fqdn=<%= Setting[:foreman_url] %> \
   --foreman-proxy-oauth-consumer-key=<%= Setting[:oauth_consumer_key] %> \
   --foreman-proxy-oauth-consumer-secret=<%= Setting[:oauth_consumer_secret] %>
 <% else %>
@@ -50,7 +49,6 @@ foreman-installer \
   --foreman-proxy-dns-reverse=<%= provisioner.rdns_zone %> \
 <%= provisioner.dns_forwarders.map { |f| "  --foreman-proxy-dns-forwarders=#{f} \\" }.join("\n") %>
 <% if defined? Katello %>
-  --foreman-proxy-content-parent-fqdn=<%= Setting[:foreman_url] %> \
   --foreman-proxy-oauth-consumer-key=<%= Setting[:oauth_consumer_key] %> \
   --foreman-proxy-oauth-consumer-secret=<%= Setting[:oauth_consumer_secret] %>
 <% else %>


### PR DESCRIPTION
The parameter `--foreman-proxy-content-parent-fqdn` does not exist anymore causing an error message when executing foreman-installer.

Related PR:
*  https://github.com/theforeman/puppet-foreman_proxy_content/commit/fabdc37e26613f62ad91319ca456137012cba1d5
